### PR TITLE
Allow creation of free plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ go get github.com/blacklightcms/recurly
 
 Import:
 ```go
-import "github.com/blacklightcms/recurly"
+import "github.com/splice/recurly"
 ```
 
 Resources:
@@ -75,8 +75,8 @@ account, err := client.Accounts.Create(ctx, recurly.Account{
 })
 ```
 
-> **NOTE**: An account can also be created along a subscription by embedding the 
-> account in the subscription during creation. The purchases API also supports 
+> **NOTE**: An account can also be created along a subscription by embedding the
+> account in the subscription during creation. The purchases API also supports
 > this, and likely other endpoints. See Recurly's documentation for details.
 
 ### Get Account
@@ -141,14 +141,14 @@ if err != nil {
     return err
 }
 ```
-> **NOTE**: Recurly offers several other ways to create subscriptions, often embedded 
-> within other requests (such as the `Purchases.Create()` call). See Recurly's 
+> **NOTE**: Recurly offers several other ways to create subscriptions, often embedded
+> within other requests (such as the `Purchases.Create()` call). See Recurly's
 > documentation for more details.
 
 ## Webhooks
-This library supports webhooks via the `webhooks` sub package. 
+This library supports webhooks via the `webhooks` sub package.
 
-The usage is to parse the webhook from a reader, then use a switch statement 
+The usage is to parse the webhook from a reader, then use a switch statement
 to determine the type of webhook received.
 
 ```go
@@ -179,11 +179,11 @@ default:
 ## Testing
 Once you've imported this library into your application, you will want to add tests.
 
-Internally this library sets up a test HTTPs server and validates methods, paths, 
+Internally this library sets up a test HTTPs server and validates methods, paths,
 query strings, request body, and returns XML. You will not need to worry about those internals
 when testing your own code that uses this library.
 
-Instead we recommend using the `mock` package. The `mock` package provides mocks 
+Instead we recommend using the `mock` package. The `mock` package provides mocks
 for all of the different services in this library.
 
 For examples of how to test your code using mocks, visit the [GoDoc examples](https://godoc.org/github.com/blacklightcms/recurly/mock/).
@@ -192,7 +192,7 @@ For examples of how to test your code using mocks, visit the [GoDoc examples](ht
 
 ## Contributing
 
-We use [`dep`](https://github.com/golang/dep) for dependency management. If you 
+We use [`dep`](https://github.com/golang/dep) for dependency management. If you
 do not have it installed, see the [installation instructions](https://github.com/golang/dep#installation).
 
 To contribute: fork and clone the repository, `cd` into the directory, and run:

--- a/accounts_test.go
+++ b/accounts_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/add_ons.go
+++ b/add_ons.go
@@ -73,6 +73,21 @@ func (u UnitAmount) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	return nil
 }
 
+// PlanUnitAmount can read or write amounts in various currencies.
+type PlanUnitAmount struct {
+	USD int `xml:"USD"`
+}
+
+// MarshalXML ensures PlanUnitAmount is not marshaled unless one or more currencies
+// has a value greater than zero.
+func (u PlanUnitAmount) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if u.USD >= 0 {
+		type uaAlias PlanUnitAmount
+		e.EncodeElement(uaAlias(u), start)
+	}
+	return nil
+}
+
 var _ AddOnsService = &addOnsImpl{}
 
 // addOnsImpl implements AddOnsService.

--- a/add_ons_test.go
+++ b/add_ons_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/adjustments_test.go
+++ b/adjustments_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/automated_exports_test.go
+++ b/automated_exports_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/billing_test.go
+++ b/billing_test.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/coupons_test.go
+++ b/coupons_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/credit_payments_test.go
+++ b/credit_payments_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestCreditPayments_List(t *testing.T) {

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ Usage
 Construct a new Recurly client, then use the various services on the client to
 access different parts of the Recurly API. For example:
 
-	import "github.com/blacklightcms/recurly"
+	import "github.com/splice/recurly"
 
 	func main() {
 		client := recurly.NewClient("your-subdomain", "APIKEY")

--- a/doc_test.go
+++ b/doc_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var client *recurly.Client

--- a/invoices_test.go
+++ b/invoices_test.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestInvoices_Encoding(t *testing.T) {

--- a/mock/accounts.go
+++ b/mock/accounts.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.AccountsService = &AccountsService{}

--- a/mock/add_ons.go
+++ b/mock/add_ons.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.AddOnsService = &AddOnsService{}

--- a/mock/adjustments.go
+++ b/mock/adjustments.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.AdjustmentsService = &AdjustmentsService{}

--- a/mock/automated_exports.go
+++ b/mock/automated_exports.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.AutomatedExportsService = &AutomatedExportsService{}

--- a/mock/billing.go
+++ b/mock/billing.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.BillingService = &BillingService{}

--- a/mock/client.go
+++ b/mock/client.go
@@ -1,7 +1,7 @@
 package mock
 
 import (
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Client is a test wrapper for recurly.Client holding mocks for

--- a/mock/coupons.go
+++ b/mock/coupons.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.CouponsService = &CouponsService{}

--- a/mock/credit_payments.go
+++ b/mock/credit_payments.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.CreditPaymentsService = &CreditPaymentsService{}

--- a/mock/example_test.go
+++ b/mock/example_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/blacklightcms/recurly/mock"
 	"github.com/google/go-cmp/cmp"
 )

--- a/mock/invoices.go
+++ b/mock/invoices.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.InvoicesService = &InvoicesService{}

--- a/mock/pager.go
+++ b/mock/pager.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.Pager = &Pager{}

--- a/mock/plans.go
+++ b/mock/plans.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.PlansService = &PlansService{}

--- a/mock/purchases.go
+++ b/mock/purchases.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.PurchasesService = &PurchasesService{}

--- a/mock/redemptions.go
+++ b/mock/redemptions.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.RedemptionsService = &RedemptionsService{}

--- a/mock/shipping_address.go
+++ b/mock/shipping_address.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.ShippingAddressesService = &ShippingAddressesService{}

--- a/mock/shipping_methods.go
+++ b/mock/shipping_methods.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.ShippingMethodsService = &ShippingMethodsService{}

--- a/mock/subscriptions.go
+++ b/mock/subscriptions.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.SubscriptionsService = &SubscriptionsService{}

--- a/mock/transactions.go
+++ b/mock/transactions.go
@@ -3,7 +3,7 @@ package mock
 import (
 	"context"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 var _ recurly.TransactionsService = &TransactionsService{}

--- a/pager_test.go
+++ b/pager_test.go
@@ -6,8 +6,8 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestPager(t *testing.T) {

--- a/plans.go
+++ b/plans.go
@@ -41,30 +41,30 @@ type PlansService interface {
 
 // Plan tells Recurly how often and how much to charge your customers.
 type Plan struct {
-	XMLName                  xml.Name   `xml:"plan"`
-	Code                     string     `xml:"plan_code,omitempty"`
-	Name                     string     `xml:"name"`
-	Description              string     `xml:"description,omitempty"`
-	SuccessURL               string     `xml:"success_url,omitempty"`
-	CancelURL                string     `xml:"cancel_url,omitempty"`
-	DisplayDonationAmounts   NullBool   `xml:"display_donation_amounts,omitempty"`
-	DisplayQuantity          NullBool   `xml:"display_quantity,omitempty"`
-	DisplayPhoneNumber       NullBool   `xml:"display_phone_number,omitempty"`
-	BypassHostedConfirmation NullBool   `xml:"bypass_hosted_confirmation,omitempty"`
-	UnitName                 string     `xml:"unit_name,omitempty"`
-	PaymentPageTOSLink       string     `xml:"payment_page_tos_link,omitempty"`
-	IntervalUnit             string     `xml:"plan_interval_unit,omitempty"`
-	IntervalLength           int        `xml:"plan_interval_length,omitempty"`
-	TrialIntervalUnit        string     `xml:"trial_interval_unit,omitempty"`
-	TrialIntervalLength      int        `xml:"trial_interval_length,omitempty"`
-	TotalBillingCycles       NullInt    `xml:"total_billing_cycles,omitempty"`
-	AccountingCode           string     `xml:"accounting_code,omitempty"`
-	CreatedAt                NullTime   `xml:"created_at,omitempty"`
-	TaxExempt                NullBool   `xml:"tax_exempt,omitempty"`
-	TaxCode                  string     `xml:"tax_code,omitempty"`
-	AutoRenew                bool       `xml:"auto_renew,omitempty"`
-	UnitAmountInCents        UnitAmount `xml:"unit_amount_in_cents"`
-	SetupFeeInCents          UnitAmount `xml:"setup_fee_in_cents,omitempty"`
+	XMLName                  xml.Name       `xml:"plan"`
+	Code                     string         `xml:"plan_code,omitempty"`
+	Name                     string         `xml:"name"`
+	Description              string         `xml:"description,omitempty"`
+	SuccessURL               string         `xml:"success_url,omitempty"`
+	CancelURL                string         `xml:"cancel_url,omitempty"`
+	DisplayDonationAmounts   NullBool       `xml:"display_donation_amounts,omitempty"`
+	DisplayQuantity          NullBool       `xml:"display_quantity,omitempty"`
+	DisplayPhoneNumber       NullBool       `xml:"display_phone_number,omitempty"`
+	BypassHostedConfirmation NullBool       `xml:"bypass_hosted_confirmation,omitempty"`
+	UnitName                 string         `xml:"unit_name,omitempty"`
+	PaymentPageTOSLink       string         `xml:"payment_page_tos_link,omitempty"`
+	IntervalUnit             string         `xml:"plan_interval_unit,omitempty"`
+	IntervalLength           int            `xml:"plan_interval_length,omitempty"`
+	TrialIntervalUnit        string         `xml:"trial_interval_unit,omitempty"`
+	TrialIntervalLength      int            `xml:"trial_interval_length,omitempty"`
+	TotalBillingCycles       NullInt        `xml:"total_billing_cycles,omitempty"`
+	AccountingCode           string         `xml:"accounting_code,omitempty"`
+	CreatedAt                NullTime       `xml:"created_at,omitempty"`
+	TaxExempt                NullBool       `xml:"tax_exempt,omitempty"`
+	TaxCode                  string         `xml:"tax_code,omitempty"`
+	AutoRenew                bool           `xml:"auto_renew,omitempty"`
+	UnitAmountInCents        PlanUnitAmount `xml:"unit_amount_in_cents"`
+	SetupFeeInCents          UnitAmount     `xml:"setup_fee_in_cents,omitempty"`
 }
 
 var _ PlansService = &plansImpl{}

--- a/plans_test.go
+++ b/plans_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.
@@ -23,11 +23,14 @@ func TestPlans_Encoding(t *testing.T) {
 			expected: MustCompactString(`
 				<plan>
 					<name></name>
+					<unit_amount_in_cents>
+						<USD>0</USD>
+					</unit_amount_in_cents>
 				</plan>
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, Description: "abc"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, Description: "abc"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -39,7 +42,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, AccountingCode: "gold"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, AccountingCode: "gold"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -51,7 +54,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, IntervalUnit: "months"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, IntervalUnit: "months"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -63,7 +66,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, IntervalLength: 1},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, IntervalLength: 1},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -75,7 +78,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, TrialIntervalUnit: "days"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TrialIntervalUnit: "days"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -87,7 +90,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", AutoRenew: true, UnitAmountInCents: recurly.UnitAmount{USD: 1500}, TrialIntervalLength: 10},
+			v: recurly.Plan{Name: "Gold plan", AutoRenew: true, UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TrialIntervalLength: 10},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -100,7 +103,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, IntervalUnit: "months"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, IntervalUnit: "months"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -112,7 +115,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, SetupFeeInCents: recurly.UnitAmount{USD: 1000, EUR: 800}},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, SetupFeeInCents: recurly.UnitAmount{USD: 1000, EUR: 800}},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -127,7 +130,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, TotalBillingCycles: recurly.NewInt(24)},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TotalBillingCycles: recurly.NewInt(24)},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -139,7 +142,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, UnitName: "unit"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, UnitName: "unit"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -151,7 +154,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, DisplayQuantity: recurly.NewBool(true)},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, DisplayQuantity: recurly.NewBool(true)},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -163,7 +166,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, DisplayQuantity: recurly.NewBool(false)},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, DisplayQuantity: recurly.NewBool(false)},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -175,7 +178,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, SuccessURL: "https://example.com/success"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, SuccessURL: "https://example.com/success"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -187,7 +190,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, CancelURL: "https://example.com/cancel"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, CancelURL: "https://example.com/cancel"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -199,7 +202,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, TaxExempt: recurly.NewBool(true)},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TaxExempt: recurly.NewBool(true)},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -211,7 +214,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, TaxExempt: recurly.NewBool(false)},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TaxExempt: recurly.NewBool(false)},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -223,7 +226,7 @@ func TestPlans_Encoding(t *testing.T) {
 			`),
 		},
 		{
-			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.UnitAmount{USD: 1500}, TaxCode: "physical"},
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TaxCode: "physical"},
 			expected: MustCompactString(`
 				<plan>
 					<name>Gold plan</name>
@@ -366,9 +369,9 @@ func TestPlans_Delete(t *testing.T) {
 
 func NewTestPlan() *recurly.Plan {
 	return &recurly.Plan{
-		XMLName:                  xml.Name{Local: "plan"},
-		Code:                     "gold",
-		Name:                     "Gold plan",
+		XMLName: xml.Name{Local: "plan"},
+		Code:    "gold",
+		Name:    "Gold plan",
 		DisplayDonationAmounts:   recurly.NewBool(false),
 		DisplayQuantity:          recurly.NewBool(false),
 		DisplayPhoneNumber:       recurly.NewBool(false),
@@ -378,9 +381,8 @@ func NewTestPlan() *recurly.Plan {
 		IntervalLength:           1,
 		TrialIntervalUnit:        "days",
 		TaxExempt:                recurly.NewBool(false),
-		UnitAmountInCents: recurly.UnitAmount{
+		UnitAmountInCents: recurly.PlanUnitAmount{
 			USD: 6000,
-			EUR: 4500,
 		},
 		SetupFeeInCents: recurly.UnitAmount{
 			USD: 1000,

--- a/purchases_test.go
+++ b/purchases_test.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/recurly_test.go
+++ b/recurly_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // MustOpenFile opens a file in the testdata directory.

--- a/redemptions_test.go
+++ b/redemptions_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestRedemptions_ListAccount(t *testing.T) {

--- a/shipping_addresses_test.go
+++ b/shipping_addresses_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestShippingAddresses_ListAccount(t *testing.T) {

--- a/shipping_methods_test.go
+++ b/shipping_methods_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestShippingMethods_Get(t *testing.T) {

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 // Ensure structs are encoded to XML properly.

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestTransactions_List(t *testing.T) {

--- a/webhooks/charge_invoices.go
+++ b/webhooks/charge_invoices.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Charge invoice notifications.

--- a/webhooks/credit_invoices.go
+++ b/webhooks/credit_invoices.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Credit invoice notifications.

--- a/webhooks/credit_payments.go
+++ b/webhooks/credit_payments.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Credit payment notifications.

--- a/webhooks/dunning_events.go
+++ b/webhooks/dunning_events.go
@@ -1,6 +1,6 @@
 package webhooks
 
-import "github.com/blacklightcms/recurly"
+import "github.com/splice/recurly"
 
 // Dunning event constants.
 const (

--- a/webhooks/payments.go
+++ b/webhooks/payments.go
@@ -3,7 +3,7 @@ package webhooks
 import (
 	"encoding/xml"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 )
 
 // Payment notifications.

--- a/webhooks/subscriptions.go
+++ b/webhooks/subscriptions.go
@@ -1,6 +1,6 @@
 package webhooks
 
-import "github.com/blacklightcms/recurly"
+import "github.com/splice/recurly"
 
 // Subscription notifications.
 // https://dev.recurly.com/page/webhooks#subscription-notifications

--- a/webhooks/webhooks_test.go
+++ b/webhooks/webhooks_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blacklightcms/recurly"
+	"github.com/splice/recurly"
 	"github.com/blacklightcms/recurly/webhooks"
 	"github.com/google/go-cmp/cmp"
 )

--- a/xml_test.go
+++ b/xml_test.go
@@ -5,8 +5,8 @@ import (
 	"encoding/xml"
 	"testing"
 
-	"github.com/blacklightcms/recurly"
 	"github.com/google/go-cmp/cmp"
+	"github.com/splice/recurly"
 )
 
 func TestXML_NullBool(t *testing.T) {


### PR DESCRIPTION
In order to create free plans we have to pass in $0 for the plan’s `UnitAmountInCents`. Currently, we set `UnitAmountInCents` only if one or more currencies value is greater than 0 (see `UnitAmount.MarshalXML` method).

Unfortunately `UnitAmountInCents` is also used in a bunch of other structs like adjustments, coupons, and subscriptions and I am too worried to change its behavior without fully understanding what the consequences of such change are, so instead I propose to use a new struct that is just used for plans, and allows us to set 0 amount for dollars. It isn’t extensible for the multi-currency world, but it will work for us since we only create plans in USD.

We only modify plans in manual tools, like `tool create-new-leasable-plugin`.