### PR TITLE
Kd/ch96321/create endpoint for getting tax preview information

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -198,7 +198,7 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 		subscriptionAlias
 		XMLName            xml.Name `xml:"subscription"`
 		AccountCode        href     `xml:"account"`
-		InvoiceNumber      int      `xml:"invoice_collection>invoice_number"`
+		InvoiceNumber      int      `xml:"invoice_collection>charge_invoice>invoice_number"`
 		TaxInCents         int      `xml:"invoice_collection>charge_invoice>tax_in_cents"`
 		TaxType            string   `xml:"invoice_collection>charge_invoice>tax_type"`
 		TaxRegion          string   `xml:"invoice_collection>charge_invoice>tax_region"`

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -125,7 +124,7 @@ type Subscription struct {
 	UnitAmountInCents      int                  `xml:"unit_amount_in_cents,omitempty"`
 	Currency               string               `xml:"currency,omitempty"`
 	Quantity               int                  `xml:"quantity,omitempty"`
-	TotalAmountInCents     int                  `xml:"total_amount_in_cents,omitempty"`
+	TotalAmountInCents     int                  `xml:"-"`
 	ActivatedAt            NullTime             `xml:"activated_at,omitempty"`
 	CanceledAt             NullTime             `xml:"canceled_at,omitempty"`
 	ExpiresAt              NullTime             `xml:"expires_at,omitempty"`
@@ -135,10 +134,10 @@ type Subscription struct {
 	TrialEndsAt            NullTime             `xml:"trial_ends_at,omitempty"`
 	PausedAt               NullTime             `xml:"paused_at,omitempty"`
 	ResumeAt               NullTime             `xml:"resume_at,omitempty"`
-	TaxInCents             int                  `xml:"tax_in_cents,omitempty"`
-	TaxType                string               `xml:"tax_type,omitempty"`
-	TaxRegion              string               `xml:"tax_region,omitempty"`
-	TaxRate                float64              `xml:"tax_rate,omitempty"`
+	TaxInCents             int                  `xml:"-"`
+	TaxType                string               `xml:"-"`
+	TaxRegion              string               `xml:"-"`
+	TaxRate                float64              `xml:"-"`
 	PONumber               string               `xml:"po_number,omitempty"`
 	NetTerms               NullInt              `xml:"net_terms,omitempty"`
 	SubscriptionAddOns     []SubscriptionAddOn  `xml:"subscription_add_ons>subscription_add_on,omitempty"`
@@ -197,9 +196,14 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	type subscriptionAlias Subscription
 	var v struct {
 		subscriptionAlias
-		XMLName       xml.Name `xml:"subscription"`
-		AccountCode   href     `xml:"account"`
-		InvoiceNumber href     `xml:"invoice"`
+		XMLName            xml.Name `xml:"subscription"`
+		AccountCode        href     `xml:"account"`
+		InvoiceNumber      int      `xml:"invoice_collection>invoice_number"`
+		TaxInCents         int      `xml:"invoice_collection>charge_invoice>tax_in_cents"`
+		TaxType            string   `xml:"invoice_collection>charge_invoice>tax_type"`
+		TaxRegion          string   `xml:"invoice_collection>charge_invoice>tax_region"`
+		TaxRate            float64  `xml:"invoice_collection>charge_invoice>tax_rate"`
+		TotalAmountInCents int      `xml:"invoice_collection>charge_invoice>total_in_cents"`
 	}
 	if err := d.DecodeElement(&v, &start); err != nil {
 		return err
@@ -208,7 +212,12 @@ func (s *Subscription) UnmarshalXML(d *xml.Decoder, start xml.StartElement) erro
 	*s = Subscription(v.subscriptionAlias)
 	s.XMLName = v.XMLName
 	s.AccountCode = v.AccountCode.LastPartOfPath()
-	s.InvoiceNumber, _ = strconv.Atoi(v.InvoiceNumber.LastPartOfPath())
+	s.InvoiceNumber = v.InvoiceNumber
+	s.TaxInCents = v.TaxInCents
+	s.TaxType = v.TaxType
+	s.TaxRegion = v.TaxRegion
+	s.TaxRate = v.TaxRate
+	s.TotalAmountInCents = v.TotalAmountInCents
 	return nil
 }
 

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -762,14 +762,14 @@ func TestSubscriptions_Preview(t *testing.T) {
 
 	s.HandleFunc("POST", "/v2/subscriptions/preview", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		w.Write(MustOpenFile("subscription.xml"))
+		w.Write(MustOpenFile("preview_subscription.xml"))
 	}, t)
 
 	if subscription, err := client.Subscriptions.Preview(context.Background(), recurly.NewSubscription{}); !s.Invoked {
 		t.Fatal("expected fn invocation")
 	} else if err != nil {
 		t.Fatal(err)
-	} else if diff := cmp.Diff(subscription, NewTestSubscription()); diff != "" {
+	} else if diff := cmp.Diff(subscription, NewTestPreviewSubscription()); diff != "" {
 		t.Fatal(diff)
 	}
 }
@@ -1080,5 +1080,36 @@ func NewTestSubscription() *recurly.Subscription {
 				},
 			},
 		},
+	}
+}
+
+// Returns a Subscription corresponding to testdata/preview_subscription.xml.
+func NewTestPreviewSubscription() *recurly.Subscription {
+	return &recurly.Subscription{
+		XMLName: xml.Name{Local: "subscription"},
+		Plan: recurly.NestedPlan{
+			Code: "gold",
+			Name: "Gold plan",
+		},
+		AccountCode:            "2",
+		InvoiceNumber:          1234,
+		UUID:                   "5378bc16986a08eb96b74345ec952abe", // UUID has been sanitized
+		State:                  "active",
+		NetTerms:               recurly.NewInt(0),
+		UnitAmountInCents:      799,
+		Currency:               "USD",
+		Quantity:               1,
+		ActivatedAt:            recurly.NewTime(time.Date(2020, time.May, 12, 0, 0, 0, 0, time.UTC)),
+		CurrentPeriodStartedAt: recurly.NewTime(time.Date(2020, time.May, 12, 0, 0, 0, 0, time.UTC)),
+		CurrentPeriodEndsAt:    recurly.NewTime(time.Date(2020, time.June, 12, 0, 0, 0, 0, time.UTC)),
+		TaxInCents:             56,
+		TotalAmountInCents:     855,
+		TaxType:                "usst",
+		TaxRegion:              "PA",
+		TaxRate:                0.07,
+		CollectionMethod:       "automatic",
+		RenewalBillingCycles:   recurly.NewInt(1),
+		RemainingBillingCycles: recurly.NewInt(0),
+		CustomFields:           &recurly.CustomFields{},
 	}
 }

--- a/testdata/preview_subscription.xml
+++ b/testdata/preview_subscription.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<subscription href="">
+  <account href="https://splicetest2.recurly.com/v2/accounts/2"/>
+  <address>
+    <name>Splice Test</name>
+    <address1>123 Main Street</address1>
+    <address2 nil="nil"></address2>
+    <city>Pittsburgh</city>
+    <state>PA</state>
+    <zip>15215</zip>
+    <country>US</country>
+    <phone nil="nil"></phone>
+  </address>
+  <plan href="https://splicetest2.recurly.com/v2/plans/gold">
+    <plan_code>gold</plan_code>
+    <name>Gold plan</name>
+  </plan>
+  <auto_renew type="boolean">false</auto_renew>
+  <renewal_billing_cycles type="integer">1</renewal_billing_cycles>
+  <current_term_started_at type="datetime"></current_term_started_at>
+  <current_term_ends_at type="datetime"></current_term_ends_at>
+  <revenue_schedule_type>evenly</revenue_schedule_type>
+  <uuid>5378bc16986a08eb96b74345ec952abe</uuid>
+  <state>active</state>
+  <unit_amount_in_cents type="integer">799</unit_amount_in_cents>
+  <currency>USD</currency>
+  <quantity type="integer">1</quantity>
+  <activated_at type="datetime">2020-05-12T00:00:00Z</activated_at>
+  <canceled_at nil="nil"></canceled_at>
+  <expires_at nil="nil"></expires_at>
+  <updated_at nil="nil"></updated_at>
+  <total_billing_cycles type="integer">1</total_billing_cycles>
+  <remaining_billing_cycles type="integer">0</remaining_billing_cycles>
+  <current_period_started_at type="datetime">2020-05-12T00:00:00Z</current_period_started_at>
+  <current_period_ends_at type="datetime">2020-06-12T00:00:00Z</current_period_ends_at>
+  <trial_started_at nil="nil"></trial_started_at>
+  <trial_ends_at nil="nil"></trial_ends_at>
+  <terms_and_conditions nil="nil"></terms_and_conditions>
+  <customer_notes nil="nil"></customer_notes>
+  <started_with_gift type="boolean">false</started_with_gift>
+  <converted_at nil="nil"></converted_at>
+  <imported_trial type="boolean">false</imported_trial>
+  <paused_at nil="nil"></paused_at>
+  <remaining_pause_cycles nil="nil"></remaining_pause_cycles>
+  <no_billing_info_reason></no_billing_info_reason>
+  <gateway_code nil="nil"></gateway_code>
+  <cost_in_cents type="integer">799</cost_in_cents>
+  <po_number nil="nil"></po_number>
+  <net_terms type="integer">0</net_terms>
+  <collection_method>automatic</collection_method>
+  <shipping_amount_in_cents>0</shipping_amount_in_cents>
+  <shipping_method_code nil="nil"></shipping_method_code>
+  <subscription_add_ons type="array">
+  </subscription_add_ons>
+  <custom_fields type="array">
+  </custom_fields>
+  <invoice_collection>
+    <charge_invoice>
+      <account href="https://splicetest2.recurly.com/v2/accounts/2"/>
+      <address>
+        <name_on_account nil="nil"></name_on_account>
+        <first_name>Splice</first_name>
+        <last_name>Test</last_name>
+        <company></company>
+        <address1>123 Main Street</address1>
+        <address2 nil="nil"></address2>
+        <city>Pittsburgh</city>
+        <state>PA</state>
+        <zip>15215</zip>
+        <country>US</country>
+        <phone nil="nil"></phone>
+      </address>
+      <uuid>5378bc1702932a2d5827814944b05f2b</uuid>
+      <state>pending</state>
+      <invoice_number_prefix></invoice_number_prefix>
+      <invoice_number type="integer"> 1234</invoice_number>
+      <vat_number nil="nil"></vat_number>
+      <tax_in_cents type="integer">56</tax_in_cents>
+      <total_in_cents type="integer">855</total_in_cents>
+      <currency>USD</currency>
+      <created_at nil="nil"></created_at>
+      <updated_at nil="nil"></updated_at>
+      <attempt_next_collection_at type="datetime">2020-05-12T17:31:18Z</attempt_next_collection_at>
+      <closed_at nil="nil"></closed_at>
+      <customer_notes></customer_notes>
+      <recovery_reason nil="nil"></recovery_reason>
+      <gateway_code nil="nil"></gateway_code>
+      <subtotal_before_discount_in_cents type="integer">799</subtotal_before_discount_in_cents>
+      <subtotal_in_cents type="integer">799</subtotal_in_cents>
+      <discount_in_cents type="integer">0</discount_in_cents>
+      <due_on type="datetime">2020-05-12T17:31:18Z</due_on>
+      <balance_in_cents type="integer">855</balance_in_cents>
+      <type>charge</type>
+      <origin>purchase</origin>
+      <refundable_total_in_cents type="integer">855</refundable_total_in_cents>
+      <credit_payments type="array">
+      </credit_payments>
+      <net_terms type="integer">0</net_terms>
+      <collection_method>automatic</collection_method>
+      <po_number nil="nil"></po_number>
+      <terms_and_conditions></terms_and_conditions>
+      <tax_type>usst</tax_type>
+      <tax_region>PA</tax_region>
+      <tax_rate type="float">0.07</tax_rate>
+      <line_items type="array">
+        <adjustment type="charge">
+          <account href="https://splicetest2.recurly.com/v2/accounts/2"/>
+          <refundable_total_in_cents type="integer">855</refundable_total_in_cents>
+          <uuid>5378bc16eba88c23ebcfa342dc8f92b6</uuid>
+          <state>pending</state>
+          <description>sounds test taxable</description>
+          <accounting_code></accounting_code>
+          <product_code>sounds-test-taxable</product_code>
+          <origin>plan</origin>
+          <unit_amount_in_cents type="integer">799</unit_amount_in_cents>
+          <quantity type="integer">1</quantity>
+          <discount_in_cents type="integer">0</discount_in_cents>
+          <tax_in_cents type="integer">56</tax_in_cents>
+          <total_in_cents type="integer">855</total_in_cents>
+          <currency>USD</currency>
+          <proration_rate nil="nil"></proration_rate>
+          <taxable type="boolean">false</taxable>
+          <tax_type>usst</tax_type>
+          <tax_region>PA</tax_region>
+          <tax_rate type="float">0.07</tax_rate>
+          <tax_exempt type="boolean">false</tax_exempt>
+          <tax_code></tax_code>
+          <start_date type="datetime">2020-05-12T17:31:18Z</start_date>
+          <end_date type="datetime">2020-06-12T17:31:18Z</end_date>
+          <created_at nil="nil"></created_at>
+          <updated_at nil="nil"></updated_at>
+          <revenue_schedule_type>evenly</revenue_schedule_type>
+        </adjustment>
+      </line_items>
+      <transactions type="array">
+      </transactions>
+    </charge_invoice>
+    <credit_invoices type="array">
+    </credit_invoices>
+  </invoice_collection>
+</subscription>


### PR DESCRIPTION
The recurly go library that we are using has the incorrect xml structure for subscription data. 

This pull request updates the subscription type to get the tax info and invoice number from the place that they are actually located in the recurly response for the version we are using. 

It also adds a test file that follows the appropriate xml structure and updates the preview test.

NOTE: I think some other tests are broken because they also use this incorrect xml structure. I can update all of them if I need to, but I only update the preview one as of this PR.