### PR TITLE
Add billing info bool to plan

### DIFF
--- a/plans.go
+++ b/plans.go
@@ -57,6 +57,7 @@ type Plan struct {
 	IntervalLength           int            `xml:"plan_interval_length,omitempty"`
 	TrialIntervalUnit        string         `xml:"trial_interval_unit,omitempty"`
 	TrialIntervalLength      int            `xml:"trial_interval_length,omitempty"`
+	TrialRequiresBillingInfo NullBool       `xml:"trial_requires_billing_info,omitempty"`
 	TotalBillingCycles       NullInt        `xml:"total_billing_cycles,omitempty"`
 	AccountingCode           string         `xml:"accounting_code,omitempty"`
 	CreatedAt                NullTime       `xml:"created_at,omitempty"`

--- a/plans_test.go
+++ b/plans_test.go
@@ -237,6 +237,19 @@ func TestPlans_Encoding(t *testing.T) {
 				</plan>
 			`),
 		},
+		{
+			v: recurly.Plan{Name: "Gold plan", UnitAmountInCents: recurly.PlanUnitAmount{USD: 1500}, TaxCode: "physical", TrialRequiresBillingInfo: recurly.NewBool(true)},
+			expected: MustCompactString(`
+				<plan>
+					<name>Gold plan</name>
+					<trial_requires_billing_info>true</trial_requires_billing_info>
+					<tax_code>physical</tax_code>
+					<unit_amount_in_cents>
+					<USD>1500</USD>
+					</unit_amount_in_cents>
+				</plan>
+			`),
+		},
 	}
 
 	for i, tt := range tests {
@@ -369,9 +382,9 @@ func TestPlans_Delete(t *testing.T) {
 
 func NewTestPlan() *recurly.Plan {
 	return &recurly.Plan{
-		XMLName: xml.Name{Local: "plan"},
-		Code:    "gold",
-		Name:    "Gold plan",
+		XMLName:                  xml.Name{Local: "plan"},
+		Code:                     "gold",
+		Name:                     "Gold plan",
 		DisplayDonationAmounts:   recurly.NewBool(false),
 		DisplayQuantity:          recurly.NewBool(false),
 		DisplayPhoneNumber:       recurly.NewBool(false),
@@ -380,6 +393,7 @@ func NewTestPlan() *recurly.Plan {
 		IntervalUnit:             "months",
 		IntervalLength:           1,
 		TrialIntervalUnit:        "days",
+		TrialRequiresBillingInfo: recurly.NewBool(false),
 		TaxExempt:                recurly.NewBool(false),
 		UnitAmountInCents: recurly.PlanUnitAmount{
 			USD: 6000,


### PR DESCRIPTION
For free plans, we do not want to require billing info for trials.  I've been having to adjust this by hand so I'm making it available to set programatically. 